### PR TITLE
Node Selector configuration for hosting service

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,13 +25,11 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-icons": "^4.2.0",
-    "react-router-dom": "^5.2.0"
-  },
-  "devDependencies": {
+    "react-router-dom": "^5.2.0",
     "@babel/core": "^7.13.14",
     "@babel/preset-env": "^7.13.12",
     "@babel/preset-react": "^7.13.13",
-    "babel-loader": "^8.2.2",
+    "babel-loader": "^8.2.3",
     "concurrently": "^6.2.0",
     "cross-env": "^7.0.3",
     "css-loader": "^5.2.0",
@@ -48,8 +46,11 @@
     "sass": "^1.32.8",
     "sass-loader": "^11.0.1",
     "style-loader": "^2.0.0",
-    "webpack": "^5.28.0",
-    "webpack-cli": "^4.6.0",
+    "webpack": "^5.69.1",
+    "webpack-cli": "^4.9.2",
     "webpack-dev-server": "^3.11.2"
+  },
+  "devDependencies": {
+    
   }
 }

--- a/server/server.js
+++ b/server/server.js
@@ -69,7 +69,7 @@ if (process.env.NODE_ENV === 'production') {
 
 // when a user goes to our url homepage serve html file
 app.get('/', (req, res) => {
-  return res.status(200).sendFile(path.join(__dirname, '../client/index.html/'));
+  return res.status(200).sendFile(path.join(__dirname, '../client/index.html'));
 });
 
 app.get('/cartoon_cow.png', (req, res) => {
@@ -78,7 +78,7 @@ app.get('/cartoon_cow.png', (req, res) => {
 
 // handle page refreshes for pages that are not the home page as well as direct manual url requests
 app.get('/*', (req, res) => {
-  return res.status(200).sendFile(path.join(__dirname, '../client/index.html/'));
+  return res.status(200).sendFile(path.join(__dirname, '../client/index.html'));
 });
 
 
@@ -92,5 +92,5 @@ app.use((err, req, res, next) => {
 })
 
 // server will listen on port '3000'
-app.listen(3000);
+app.listen(0);
 


### PR DESCRIPTION
- Moved all dev dependencies to dependencies in package.json file due to Node Selector being unable to find packages that existed in dev dependencies
- All paths passed into sendFile method ending with a slash cause an error when file were being served on Node selector, so removed all slashes and was necessary for our server to obatin a port number dynamically in order to run.